### PR TITLE
AVL-4: Create Tree from Array

### DIFF
--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -27,8 +27,10 @@ describe('AVL Tree creation', () => {
     });
     test('should return proper insertion order when created from an array', () => {
         let tree = Tree.fromArray(['a', 'b', 'c']);
-        let infix = tree.toArray();
-        expect(infix).toStrictEqual(['a', 'b', 'c']);
+        expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
+        expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
+        expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
+    
     });
     test('should throw an error when a source is not an array', () => {
         expect(() => Tree.fromArray('x')).toThrow('Cannot create tree from non-array source');

--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -6,6 +6,38 @@ test('throw error on duplicate key', () => {
     expect(() => t.add('a')).toThrow('Adding multiple values with the same key not implemented.');
 });
 
+/* CREATION
+ */
+describe('AVL Tree creation', () => {
+    test('should create an empty tree on construction', () => {
+        let tree = new Tree();
+        expect(tree.root).toBeTruthy();
+        expect(tree.root.payload).toBe(null);
+        expect(tree.root.left).toBe(null);
+        expect(tree.root.right).toBe(null);
+        expect(tree.root.balance).toBe('BALANCED');
+    });
+    test('should return an empty tree when a source array is empty', () => {
+        let tree = Tree.fromArray([]);
+        expect(tree.root).toBeTruthy();
+        expect(tree.root.payload).toBe(null);
+        expect(tree.root.left).toBe(null);
+        expect(tree.root.right).toBe(null);
+        expect(tree.root.balance).toBe('BALANCED');
+    });
+    test('should return proper insertion order when created from an array', () => {
+        let tree = Tree.fromArray(['a', 'b', 'c']);
+        let infix = tree.toArray();
+        expect(infix).toStrictEqual(['a', 'b', 'c']);
+    });
+    test('should throw an error when a source is not an array', () => {
+        expect(() => Tree.fromArray('x')).toThrow('Cannot create tree from non-array source');
+        expect(() => Tree.fromArray(1)).toThrow('Cannot create tree from non-array source');
+        expect(() => Tree.fromArray(true)).toThrow('Cannot create tree from non-array source');
+        expect(() => Tree.fromArray({})).toThrow('Cannot create tree from non-array source');
+    });
+});
+
 /* SINGLE ROTATIONS
  * ----------------
  */

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -9,6 +9,7 @@ class Node {
         this.payload = null;
         this.left = null;
         this.right = null;
+        this.balance = BALANCED;
         this.metrics = new Metrics();
     }
 

--- a/src/avltree.js
+++ b/src/avltree.js
@@ -17,6 +17,14 @@ class Tree {
         return out;
     }
 
+    static fromArray(source) {
+        if (!Array.isArray(source))
+            throw new Error(`Cannot create tree from non-array source`);
+        let tree = new Tree();
+        source.forEach(element => tree.add(element));
+        return tree;
+    }
+
     metrics() {
         return this.root.getMetrics();
     }


### PR DESCRIPTION
``` console
> @ogrefied/avl-tree@0.5.1 test
> jest

 PASS  __tests__/avltree.test.js
  ✓ throw error on duplicate key (18 ms)
  ✓ it should rotate left (1 ms)
  ✓ it should rotate right
  ✓ R balance, double rotation, left high new root
  ✓ R balance, double rotation, right high new root (1 ms)
  ✓ R balance, double rotation, balanced new root (1 ms)
  ✓ L balance, double rotation, right high new root
  ✓ L balance, double rotation, left high new root (1 ms)
  ✓ L balance, double rotation, balanced new root (1 ms)
  ✓ should be 3 inserts, 3 adds, and right balance with double rotation
  ✓ double rotation at non-root node on right (1 ms)
  ✓ double rotation at non-root node on left
  AVL Tree creation
    ✓ should create an empty tree on construction (1 ms)
    ✓ should return an empty tree when a source array is empty
    ✓ should return proper insertion order when created from an array (3 ms)
    ✓ should throw an error when a source is not an array (2 ms)

---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |     100 |      100 |     100 |     100 |                   
 avlmetrics.js |     100 |      100 |     100 |     100 |                   
 avlnode.js    |     100 |      100 |     100 |     100 |                   
 avltree.js    |     100 |      100 |     100 |     100 |                   
---------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        0.408 s, estimated 1 s
Ran all test suites.
```