### PR TITLE
AVL-9: Compute Tree Depth

### DIFF
--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -15,7 +15,7 @@ test('throw error on duplicate key', () => {
 
 describe('AVL Tree creation', () => {
     test('should create an empty tree on construction', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         expect(tree.root).toBeTruthy();
         expect(tree.root.payload).toBe(null);
         expect(tree.root.left).toBe(null);
@@ -23,7 +23,7 @@ describe('AVL Tree creation', () => {
         expect(tree.root.balance).toBe('BALANCED');
     });
     test('should return an empty tree when a source array is empty', () => {
-        let tree = Tree.fromArray([]);
+        const tree = Tree.fromArray([]);
         expect(tree.root).toBeTruthy();
         expect(tree.root.payload).toBe(null);
         expect(tree.root.left).toBe(null);
@@ -31,7 +31,7 @@ describe('AVL Tree creation', () => {
         expect(tree.root.balance).toBe('BALANCED');
     });
     test('should return proper insertion order when created from an array', () => {
-        let tree = Tree.fromArray(['a', 'b', 'c']);
+        const tree = Tree.fromArray(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
@@ -45,20 +45,20 @@ describe('AVL Tree creation', () => {
 });
 describe('AVL Tree insertions', () => {
     test('should throw an error when a mismatched type is inserted', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('a');
         expect(() => tree.add(1)).toThrow(new AvlTreeTypeMismatchError('number', 'string').toString());
         expect(() => tree.add({})).toThrow(new AvlTreeTypeMismatchError('object', 'string').toString());
     });
     test('should throw an error when a nullish value is inserted', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         expect(() => tree.add(null)).toThrow(new AvlTreeEmptyPayloadError().toString());
         expect(() => tree.add(undefined)).toThrow(new AvlTreeEmptyPayloadError().toString());
     });
 
     // SINGLE ROTATIONS
     test('should result in a left rotation when added in sequence order', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('a');
         tree.add('b');
         tree.add('c');
@@ -75,7 +75,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toBeUndefined();
     });
     test('should result in a right rotation when added in reverse order', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('c');
         tree.add('b');
         tree.add('a');
@@ -94,7 +94,7 @@ describe('AVL Tree insertions', () => {
 
     // DOUBLE ROTATIONS
     test('should right balance with a double rotation when the new root was left high after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('b');
         tree.add('a');
         tree.add('e');
@@ -114,7 +114,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toBeUndefined();
     });
     test('should right balance with a double rotation when the new root was right high after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('b');
         tree.add('a');
         tree.add('e');
@@ -134,7 +134,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toBeUndefined();
     });
     test('should right balance with a double rotation when the new root is balanced after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('a');
         tree.add('c');
         tree.add('b'); //rightBalance via double rotation
@@ -151,7 +151,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toBeUndefined();
     });
     test('should left balance with a double rotation when the new root is right high after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('e');
         tree.add('f');
         tree.add('b');
@@ -171,7 +171,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toEqual(1);
     });
     test('should left balance with a double rotation when the new root is left high after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('e');
         tree.add('f');
         tree.add('b');
@@ -191,7 +191,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toEqual(1);
     });
     test('should left balance with a double rotation when the new root is balanced after the insertion', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('c');
         tree.add('a');
         tree.add('b'); //rightBalance via double rotation
@@ -208,7 +208,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toEqual(1);
     });
     test('should right balance with a double rotation on a non-root node', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('b');
         tree.add('a');
         tree.add('c');
@@ -227,7 +227,7 @@ describe('AVL Tree insertions', () => {
         expect(metrics.leftBalance).toBeUndefined();
     });
     test('should left balance with a double rotation on a non-root node', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('d');
         tree.add('e');
         tree.add('c');
@@ -249,7 +249,7 @@ describe('AVL Tree insertions', () => {
 
 describe('AVL Tree output to array', () => {
     test('should print in infix notation by default', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('d');
         tree.add('e');
         tree.add('c');
@@ -271,13 +271,13 @@ describe('AVL Tree output to array', () => {
 
 describe('AVL Tree search', () => {
     test('should throw if the search value is null or undefined', () => {
-        let tree = new Tree();
+        const tree = new Tree();
         tree.add('a');
         expect(() => tree.find(null)).toThrow(new AvlTreeSearchValueEmptyError().toString());
         expect(() => tree.find(undefined)).toThrow(new AvlTreeSearchValueEmptyError().toString());
     });
     test('should return a node that matches the search value exactly', () => {
-        let tree = Tree.fromArray(['a', 'b', 'c', 'd', 'e', 'f']);
+        const tree = Tree.fromArray(['a', 'b', 'c', 'd', 'e', 'f']);
         const { node, metrics } = tree.find('c');
         expect(node.payload).toEqual('c');
         expect(metrics.searchLeft).toEqual(1);
@@ -285,7 +285,7 @@ describe('AVL Tree search', () => {
         expect(metrics.depth).toEqual(2);
     });
     test('should return null if the search term is not found', () => {
-        let tree = Tree.fromArray(['a', 'c', 'e', 'g', 'i', 'k']);
+        const tree = Tree.fromArray(['a', 'c', 'e', 'g', 'i', 'k']);
         const { node: nodeM, metrics: metricsM } = tree.find('m');
         expect(nodeM).toEqual(null);
         expect(metricsM.searchLeft).toBeUndefined();
@@ -296,5 +296,43 @@ describe('AVL Tree search', () => {
         expect(metricsJ.searchLeft).toEqual(1);
         expect(metricsJ.searchRight).toEqual(2);
         expect(metricsJ.depth).toEqual(3);
+    });
+});
+
+describe('AVL Tree depth', () => {
+    test('should be zero for a new tree', () => {
+        const tree = new Tree();
+        const { depth, searchLeft, searchRight } = tree.depth();
+        expect(depth).toEqual(0);
+        expect(searchLeft).toEqual(0);
+        expect(searchRight).toEqual(0);
+    });
+    test('should be one for a tree with a single node', () => {
+        const tree = Tree.fromArray(['a']);
+        const { depth, searchLeft, searchRight } = tree.depth();
+        expect(depth).toEqual(1);
+        expect(searchLeft).toEqual(0);
+        expect(searchRight).toEqual(0);
+    });
+    test('should be two for a balanced tree with three nodes', () => {
+        const tree = Tree.fromArray(['b', 'a', 'c']);
+        const { depth, searchLeft, searchRight } = tree.depth();
+        expect(depth).toEqual(2);
+        expect(searchLeft).toEqual(1);
+        expect(searchRight).toEqual(0);
+    });
+    test('should only result in depth-1 searches when the tree is left high', () => {
+        const tree = Tree.fromArray(['m', 'i', 'p', 'e', 'j']);
+        const { depth, searchLeft, searchRight } = tree.depth();
+        expect(depth).toEqual(3);
+        expect(searchLeft).toEqual(2);
+        expect(searchRight).toEqual(0);
+    });
+    test('should only result in depth-1 searches when the tree is right high', () => {
+        const tree = Tree.fromArray(['m', 'i', 'p', 'o', 't']);
+        const { depth, searchLeft, searchRight } = tree.depth();
+        expect(depth).toEqual(3);
+        expect(searchLeft).toEqual(1);
+        expect(searchRight).toEqual(1);
     });
 });

--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -286,7 +286,6 @@ describe('AVL Tree search', () => {
     });
     test('should return null if the search term is not found', () => {
         let tree = Tree.fromArray(['a', 'c', 'e', 'g', 'i', 'k']);
-        console.log(`tree: ${JSON.stringify(tree)}`);
         const { node: nodeM, metrics: metricsM } = tree.find('m');
         expect(nodeM).toEqual(null);
         expect(metricsM.searchLeft).toBeUndefined();

--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -1,8 +1,10 @@
 import { Tree } from '../src/avltree';
+import { Metrics } from '../src/avlmetrics';
 import {
     AvlTreeConstructionError,
     AvlTreeDuplicateKeyError,
     AvlTreeEmptyPayloadError,
+    AvlTreeParameterTypeMismatchError,
     AvlTreeSearchValueEmptyError,
     AvlTreeTypeMismatchError,
 } from '../src/avlerrors';
@@ -302,37 +304,47 @@ describe('AVL Tree search', () => {
 describe('AVL Tree depth', () => {
     test('should be zero for a new tree', () => {
         const tree = new Tree();
-        const { depth, searchLeft, searchRight } = tree.depth();
-        expect(depth).toEqual(0);
-        expect(searchLeft).toEqual(0);
-        expect(searchRight).toEqual(0);
+        expect(tree.depth()).toEqual(0);
     });
     test('should be one for a tree with a single node', () => {
         const tree = Tree.fromArray(['a']);
-        const { depth, searchLeft, searchRight } = tree.depth();
-        expect(depth).toEqual(1);
-        expect(searchLeft).toEqual(0);
-        expect(searchRight).toEqual(0);
+        expect(tree.depth()).toEqual(1);
+    });
+    test('should report the number of left and right traversals if a Metrics object is provided', () => {
+        const tree = Tree.fromArray(['m', 'i', 'p', 'o', 't']);
+        const metrics = new Metrics();
+        const depth = tree.depth(metrics);
+        expect(depth).toEqual(3);
+        expect(metrics.counters.searchLeft).toEqual(1);
+        expect(metrics.counters.searchRight).toEqual(1);
+    });
+    test('should throw an error if a non-Metrics type is passed as a collector', () => {
+        const tree = new Tree();
+        expect(() => tree.depth(1)).toThrow(new AvlTreeParameterTypeMismatchError('Metrics', 'number').toString())
+        expect(() => tree.depth({})).toThrow(new AvlTreeParameterTypeMismatchError('Metrics', 'object').toString())
     });
     test('should be two for a balanced tree with three nodes', () => {
         const tree = Tree.fromArray(['b', 'a', 'c']);
-        const { depth, searchLeft, searchRight } = tree.depth();
+        const metrics = new Metrics();
+        const depth = tree.depth(metrics);
         expect(depth).toEqual(2);
-        expect(searchLeft).toEqual(1);
-        expect(searchRight).toEqual(0);
+        expect(metrics.counters.searchLeft).toEqual(1);
+        expect(metrics.counters.searchRight).toBeUndefined();
     });
     test('should only result in depth-1 searches when the tree is left high', () => {
         const tree = Tree.fromArray(['m', 'i', 'p', 'e', 'j']);
-        const { depth, searchLeft, searchRight } = tree.depth();
+        const metrics = new Metrics();
+        const depth = tree.depth(metrics);
         expect(depth).toEqual(3);
-        expect(searchLeft).toEqual(2);
-        expect(searchRight).toEqual(0);
+        expect(metrics.counters.searchLeft).toEqual(2);
+        expect(metrics.counters.searchRight).toBeUndefined();
     });
     test('should only result in depth-1 searches when the tree is right high', () => {
         const tree = Tree.fromArray(['m', 'i', 'p', 'o', 't']);
-        const { depth, searchLeft, searchRight } = tree.depth();
+        const metrics = new Metrics();
+        const depth = tree.depth(metrics);
         expect(depth).toEqual(3);
-        expect(searchLeft).toEqual(1);
-        expect(searchRight).toEqual(1);
+        expect(metrics.counters.searchLeft).toEqual(1);
+        expect(metrics.counters.searchRight).toEqual(1);
     });
 });

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,11 @@
+# Version 1.0.0
+* AVL-4 Instantiate a Tree from an array
+* AVL-9 Compute the depth of a Tree
+* AVL-21 Search the Tree for an exact value
+* Metric refactoring and Metrics now distinguishes between left and right adds
+* Fixed double accounting issue in Metrics
+* Test refactoring and more extensive test cases
+
+# Version 0.5.0
+* Initial release
+* Permits adding only via Tree.add()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ogrefied/avl-tree",
-    "version": "0.5.1",
+    "version": "1.0.0",
     "description": "Implements a self-balancing binary tree",
     "main": "index.js",
     "scripts": {

--- a/src/avlerrors.js
+++ b/src/avlerrors.js
@@ -39,6 +39,12 @@ export class AvlTreeEmptyPayloadError extends AvlTreeError {
     }
 }
 
+export class AvlTreeParameterTypeMismatchError extends AvlTreeError {
+    constructor(expectedType, foundType) {
+        super(`Parameter Type Mismatch: Expected type ${expectedType} but found ${foundType}`);
+    }
+}
+
 export class AvlTreeRotateLeftWithoutRightChildError extends AvlTreeError {
     constructor(nodePayload) {
         super(`Rotation Error: Cannot rotate left without right-hand child at node: ${nodePayload}`);

--- a/src/avlmetrics.js
+++ b/src/avlmetrics.js
@@ -10,7 +10,7 @@ export class Metrics {
     
     increment(counter) {
         if (!this.counters[counter])
-            this.counters[counter] = 0;
+            this.initialize(counter, 0);
         this.counters[counter]++;
         return this.counters[counter];
     }

--- a/src/avlmetrics.js
+++ b/src/avlmetrics.js
@@ -10,7 +10,7 @@ export class Metrics {
     
     increment(counter) {
         if (!this.counters[counter])
-            this.initialize(counter, 0);
+            this.initialize(counter);
         this.counters[counter]++;
         return this.counters[counter];
     }

--- a/src/avlmetrics.js
+++ b/src/avlmetrics.js
@@ -3,6 +3,11 @@ export class Metrics {
         this.counters = {}
     }
 
+    initialize(counter, value = 0) {
+        this.counters[counter] = value;
+        return this.counters[counter];
+    }
+    
     increment(counter) {
         if (!this.counters[counter])
             this.counters[counter] = 0;

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -23,6 +23,30 @@ export class Node {
         this.metrics = new Metrics();
     }
 
+    depth(callMetrics) {
+        if (this.balance === RIGHT_HIGH) {
+            callMetrics.increment('depth');
+            callMetrics.increment('searchRight');
+            this.metrics.increment('searchRight');
+            return this.right.depth(callMetrics);
+        } else if (this.balance === LEFT_HIGH) {
+            callMetrics.increment('depth');
+            callMetrics.increment('searchLeft');
+            this.metrics.increment('searchLeft');
+            return this.left.depth(callMetrics);
+        }
+        if (this.left == null && this.right == null) {
+            if (this.payload != null) {
+                callMetrics.increment('depth');
+            }
+            return callMetrics;
+        }
+        callMetrics.increment('depth');
+        callMetrics.increment('searchLeft');
+        this.metrics.increment('searchLeft');
+        return this.left.depth(callMetrics);
+    }
+
     getMetrics() {
         let all = { ...this.metrics.counters };
         const lm = this.left ? this.left.getMetrics() : {};

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -25,11 +25,11 @@ export class Node {
 
     depth(level, callMetrics) {
         if (this.balance === RIGHT_HIGH) {
-            callMetrics && callMetrics.increment('searchRight');
+            callMetrics?.increment('searchRight');
             this.metrics.increment('searchRight');
             return this.right.depth(++level, callMetrics);
         } else if (this.balance === LEFT_HIGH) {
-            callMetrics && callMetrics.increment('searchLeft');
+            callMetrics?.increment('searchLeft');
             this.metrics.increment('searchLeft');
             return this.left.depth(++level, callMetrics);
         }
@@ -39,7 +39,7 @@ export class Node {
             }
             return level;
         }
-        callMetrics && callMetrics.increment('searchLeft');
+        callMetrics?.increment('searchLeft');
         this.metrics.increment('searchLeft');
         return this.left.depth(++level, callMetrics);
     }
@@ -57,19 +57,19 @@ export class Node {
         switch (notation) {
             case 'prefix':
                 out.push(this.payload);
-                this.left && this.left.toArray(out, notation);
-                this.right && this.right.toArray(out, notation);
+                this.left?.toArray(out, notation);
+                this.right?.toArray(out, notation);
                 break;
             case 'postfix':
-                this.left && this.left.toArray(out, notation);
-                this.right && this.right.toArray(out, notation);
+                this.left?.toArray(out, notation);
+                this.right?.toArray(out, notation);
                 out.push(this.payload);
                 break;
             case 'infix':
             default:
-                this.left && this.left.toArray(out, notation);
+                this.left?.toArray(out, notation);
                 out.push(this.payload);
-                this.right && this.right.toArray(out, notation);
+                this.right?.toArray(out, notation);
                 break;
         }
     }

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -23,28 +23,25 @@ export class Node {
         this.metrics = new Metrics();
     }
 
-    depth(callMetrics) {
+    depth(level, callMetrics) {
         if (this.balance === RIGHT_HIGH) {
-            callMetrics.increment('depth');
-            callMetrics.increment('searchRight');
+            callMetrics && callMetrics.increment('searchRight');
             this.metrics.increment('searchRight');
-            return this.right.depth(callMetrics);
+            return this.right.depth(++level, callMetrics);
         } else if (this.balance === LEFT_HIGH) {
-            callMetrics.increment('depth');
-            callMetrics.increment('searchLeft');
+            callMetrics && callMetrics.increment('searchLeft');
             this.metrics.increment('searchLeft');
-            return this.left.depth(callMetrics);
+            return this.left.depth(++level, callMetrics);
         }
         if (this.left == null && this.right == null) {
             if (this.payload != null) {
-                callMetrics.increment('depth');
+                return level + 1;
             }
-            return callMetrics;
+            return level;
         }
-        callMetrics.increment('depth');
-        callMetrics.increment('searchLeft');
+        callMetrics && callMetrics.increment('searchLeft');
         this.metrics.increment('searchLeft');
-        return this.left.depth(callMetrics);
+        return this.left.depth(++level, callMetrics);
     }
 
     getMetrics() {

--- a/src/avltree.js
+++ b/src/avltree.js
@@ -1,6 +1,7 @@
 import { Node } from './avlnode';
 import {
     AvlTreeConstructionError,
+    AvlTreeParameterTypeMismatchError,
     AvlTreeSearchValueEmptyError,
 } from './avlerrors';
 import { Metrics } from './avlmetrics';
@@ -16,12 +17,11 @@ export class Tree {
             this.root = newRootNode;
     }
 
-    depth() {
-        let metrics = new Metrics();
-        metrics.initialize('depth');
-        metrics.initialize('searchLeft');
-        metrics.initialize('searchRight');
-        return this.root.depth(metrics).counters;
+    depth(callMetrics = null) {
+        if (callMetrics != null && !(callMetrics instanceof Metrics))
+            throw new AvlTreeParameterTypeMismatchError('Metrics', typeof callMetrics);
+        let level = 0;
+        return this.root.depth(level, callMetrics);
     }
 
     find(value) {

--- a/src/avltree.js
+++ b/src/avltree.js
@@ -16,6 +16,14 @@ export class Tree {
             this.root = newRootNode;
     }
 
+    depth() {
+        let metrics = new Metrics();
+        metrics.initialize('depth');
+        metrics.initialize('searchLeft');
+        metrics.initialize('searchRight');
+        return this.root.depth(metrics).counters;
+    }
+
     find(value) {
         if (value == null)
             throw new AvlTreeSearchValueEmptyError();


### PR DESCRIPTION
``` console
> @ogrefied/avl-tree@1.0.0 test
> jest

 PASS  __tests__/avltree.test.js
  ✓ throw error on duplicate key (1 ms)
  AVL Tree creation
    ✓ should create an empty tree on construction (1 ms)
    ✓ should return an empty tree when a source array is empty (1 ms)
    ✓ should return proper insertion order when created from an array (1 ms)
    ✓ should throw an error when a source is not an array (1 ms)
  AVL Tree insertions
    ✓ should throw an error when a mismatched type is inserted
    ✓ should throw an error when a nullish value is inserted
    ✓ should result in a left rotation when added in sequence order (2 ms)
    ✓ should result in a right rotation when added in reverse order (1 ms)
    ✓ should right balance with a double rotation when the new root was left high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root was right high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root is balanced after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is right high after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is left high after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is balanced after the insertion (1 ms)
    ✓ should right balance with a double rotation on a non-root node (3 ms)
    ✓ should left balance with a double rotation on a non-root node (1 ms)
  AVL Tree output to array
    ✓ should print in infix notation by default (1 ms)
  AVL Tree search
    ✓ should throw if the search value is null or undefined
    ✓ should return a node that matches the search value exactly (1 ms)
    ✓ should return null if the search term is not found (1 ms)
  AVL Tree depth
    ✓ should be zero for a new tree
    ✓ should be one for a tree with a single node
    ✓ should report the number of left and right traversals if a Metrics object is provided
    ✓ should throw an error if a non-Metrics type is passed as a collector
    ✓ should be two for a balanced tree with three nodes
    ✓ should only result in depth-1 searches when the tree is left high (1 ms)
    ✓ should only result in depth-1 searches when the tree is right high

---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |   97.69 |      100 |   86.84 |   97.66 |                   
 avlerrors.js  |   61.53 |      100 |   61.53 |   61.53 | 14-20,50-62       
 avlmetrics.js |     100 |      100 |     100 |     100 |                   
 avlnode.js    |     100 |      100 |     100 |     100 |                   
 avltree.js    |     100 |      100 |     100 |     100 |                   
---------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       28 passed, 28 total
Snapshots:   0 total
Time:        0.567 s, estimated 1 s
Ran all test suites.
```