### PR TITLE
AVL-23: Every Node Has a Parent

### DIFF
--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -9,12 +9,6 @@ import {
     AvlTreeTypeMismatchError,
 } from '../src/avlerrors';
 
-test('throw error on duplicate key', () => {
-    let t = new Tree();
-    t.add('a');
-    expect(() => t.add('a')).toThrow(new AvlTreeDuplicateKeyError('a').toString());
-});
-
 describe('AVL Tree creation', () => {
     test('should create an empty tree on construction', () => {
         const tree = new Tree();
@@ -57,7 +51,21 @@ describe('AVL Tree insertions', () => {
         expect(() => tree.add(null)).toThrow(new AvlTreeEmptyPayloadError().toString());
         expect(() => tree.add(undefined)).toThrow(new AvlTreeEmptyPayloadError().toString());
     });
-
+    test('should throw an error on duplicate key', () => {
+        const tree = new Tree();
+        tree.add('a');
+        expect(() => tree.add('a')).toThrow(new AvlTreeDuplicateKeyError('a').toString());
+    });
+    test('should set the parent of the root node to null', () => {
+        const tree = new Tree();
+        expect(tree.root.parent).toEqual(null);
+    });
+    test('should set the parent of a new node', () => {
+        const tree = new Tree();
+        tree.add('a');
+        tree.add('b');
+        expect(tree.root.right.parent).toEqual(tree.root);
+    });
     // SINGLE ROTATIONS
     test('should result in a left rotation when added in sequence order', () => {
         const tree = new Tree();
@@ -67,6 +75,8 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toBeUndefined();
         expect(metrics.addRight).toEqual(3); // 2 right a, 1 right of b
@@ -84,6 +94,8 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(3); // 2 left of c, 1 left of b
         expect(metrics.addRight).toBeUndefined();
@@ -106,6 +118,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e', 'f']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['d', 'b', 'a', 'c', 'e', 'f']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b', 'f', 'e', 'd']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.right.right.parent).toEqual(tree.root.right);
+        expect(tree.root.left.left.parent).toEqual(tree.root.left);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(4);
         expect(metrics.addRight).toEqual(5);
@@ -126,6 +142,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e', 'f']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['c', 'b', 'a', 'e', 'd', 'f']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'b', 'd', 'f', 'e', 'c']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.right.right.parent).toEqual(tree.root.right);
+        expect(tree.root.left.left.parent).toEqual(tree.root.left);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(3);
         expect(metrics.addRight).toEqual(6);
@@ -143,6 +163,8 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(1);
         expect(metrics.addRight).toEqual(2);
@@ -163,6 +185,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e', 'f']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['c', 'b', 'a', 'e', 'd', 'f']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'b', 'd', 'f', 'e', 'c']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.right.right.parent).toEqual(tree.root.right);
+        expect(tree.root.left.left.parent).toEqual(tree.root.left);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(5);
         expect(metrics.addRight).toEqual(4);
@@ -183,6 +209,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e', 'f']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['d', 'b', 'a', 'c', 'e', 'f']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b', 'f', 'e', 'd']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.right.right.parent).toEqual(tree.root.right);
+        expect(tree.root.left.left.parent).toEqual(tree.root.left);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(6);
         expect(metrics.addRight).toEqual(3);
@@ -200,6 +230,8 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'c']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(2);
         expect(metrics.addRight).toEqual(1);
@@ -219,6 +251,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['b', 'a', 'd', 'c', 'e']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'e', 'd', 'b']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.right.right.parent).toEqual(tree.root.right);
+        expect(tree.root.right.left.parent).toEqual(tree.root.right);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(2);
         expect(metrics.addRight).toEqual(5);
@@ -238,6 +274,10 @@ describe('AVL Tree insertions', () => {
         expect(tree.toArray({ notation: 'infix' })).toStrictEqual(['a', 'b', 'c', 'd', 'e']);
         expect(tree.toArray({ notation: 'prefix' })).toStrictEqual(['d', 'b', 'a', 'c', 'e']);
         expect(tree.toArray({ notation: 'postfix' })).toStrictEqual(['a', 'c', 'b', 'e', 'd']);
+        expect(tree.root.right.parent).toEqual(tree.root);
+        expect(tree.root.left.parent).toEqual(tree.root);
+        expect(tree.root.left.right.parent).toEqual(tree.root.left);
+        expect(tree.root.left.left.parent).toEqual(tree.root.left);
         const metrics = tree.metrics();
         expect(metrics.addLeft).toEqual(5);
         expect(metrics.addRight).toEqual(2);

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -15,10 +15,11 @@ const BALANCED = 'BALANCED';
 const RIGHT_HIGH = 'RIGHT_HIGH';
 
 export class Node {
-    constructor() {
+    constructor(parent) {
         this.payload = null;
         this.left = null;
         this.right = null;
+        this.parent = parent ?? null;
         this.balance = BALANCED;
         this.metrics = new Metrics();
     }
@@ -86,8 +87,12 @@ export class Node {
             throw new AvlTreeRotateLeftWithoutRightChildError(oldRoot.payload);
         oldRoot.metrics.increment('rotateLeft');
         let newRoot = oldRoot.right;
+        newRoot.parent = oldRoot.parent;
         oldRoot.right = newRoot.left;
+        if (newRoot.left)
+            newRoot.left.parent = oldRoot;
         newRoot.left = oldRoot;
+        oldRoot.parent = newRoot;
         return newRoot;
     }
 
@@ -100,8 +105,12 @@ export class Node {
         if (!oldRoot.left)
             throw new AvlTreeRotateRightWithoutLeftChildError(oldRoot.payload);
         let newRoot = oldRoot.left;
+        newRoot.parent = oldRoot.parent;
         oldRoot.left = newRoot.right;
+        if (newRoot.right)
+            newRoot.right.parent = oldRoot;
         newRoot.right = oldRoot;
+        oldRoot.parent = newRoot;
         return newRoot;
     }
 
@@ -226,7 +235,7 @@ export class Node {
             throw new AvlTreeTypeMismatchError(insertedType, existingType);
         if (payload > this.payload) {   //add right
             if (!this.right)
-                this.right = new Node();
+                this.right = new Node(this);
             let taller;
             this.metrics.increment('addRight');
             ({ taller, newRootNode } = this.right.add(payload));
@@ -264,7 +273,7 @@ export class Node {
             }
         } else if (payload < this.payload) {    //add left
             if (!this.left)
-                this.left = new Node();
+                this.left = new Node(this);
             let taller;
             this.metrics.increment('addLeft');
             ({ taller, newRootNode } = this.left.add(payload));


### PR DESCRIPTION
``` console
> @ogrefied/avl-tree@1.0.0 test
> jest

 PASS  __tests__/avltree.test.js
  AVL Tree creation
    ✓ should create an empty tree on construction (1 ms)
    ✓ should return an empty tree when a source array is empty
    ✓ should return proper insertion order when created from an array (2 ms)
    ✓ should throw an error when a source is not an array (1 ms)
  AVL Tree insertions
    ✓ should throw an error when a mismatched type is inserted
    ✓ should throw an error when a nullish value is inserted
    ✓ show throw an error on duplicate key
    ✓ should set the parent of the root node to null (1 ms)
    ✓ should set the parent of a new node
    ✓ should result in a left rotation when added in sequence order (2 ms)
    ✓ should result in a right rotation when added in reverse order (1 ms)
    ✓ should right balance with a double rotation when the new root was left high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root was right high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root is balanced after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is right high after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is left high after the insertion (2 ms)
    ✓ should left balance with a double rotation when the new root is balanced after the insertion
    ✓ should right balance with a double rotation on a non-root node
    ✓ should left balance with a double rotation on a non-root node (1 ms)
  AVL Tree output to array
    ✓ should print in infix notation by default
  AVL Tree search
    ✓ should throw if the search value is null or undefined
    ✓ should return a node that matches the search value exactly
    ✓ should return null if the search term is not found
  AVL Tree depth
    ✓ should be zero for a new tree
    ✓ should be one for a tree with a single node
    ✓ should report the number of left and right traversals if a Metrics object is provided
    ✓ should throw an error if a non-Metrics type is passed as a collector
    ✓ should be two for a balanced tree with three nodes
    ✓ should only result in depth-1 searches when the tree is left high
    ✓ should only result in depth-1 searches when the tree is right high (1 ms)

---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |   97.78 |      100 |   86.84 |   97.75 |                   
 avlerrors.js  |   61.53 |      100 |   61.53 |   61.53 | 14-20,50-62       
 avlmetrics.js |     100 |      100 |     100 |     100 |                   
 avlnode.js    |     100 |      100 |     100 |     100 |                   
 avltree.js    |     100 |      100 |     100 |     100 |                   
---------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       30 passed, 30 total
Snapshots:   0 total
Time:        0.603 s, estimated 1 s
Ran all test suites.
```