### PR TITLE
AVL-25: Output Tree to Non-Circular JSON

### DIFF
--- a/__tests__/avltree.test.js
+++ b/__tests__/avltree.test.js
@@ -311,6 +311,18 @@ describe('AVL Tree output to array', () => {
     });
 });
 
+describe('AVL Tree output to JSON', () => {
+    test('should contain all fields but parent', () => {
+        const tree = Tree.fromArray(['a', 'c', 'e', 'g', 'i', 'k']);
+        const json = tree.toJson();
+        const jsonString = JSON.stringify(json);
+        expect(jsonString.length).toBe(743);
+        expect(tree.root.left.parent).toBeTruthy();
+        expect(tree.root.right.parent).toBeTruthy();
+        expect(json.left.parent).toBeUndefined();
+        expect(json.right.parent).toBeUndefined();
+    });
+});
 describe('AVL Tree search', () => {
     test('should throw if the search value is null or undefined', () => {
         const tree = new Tree();

--- a/src/avlnode.js
+++ b/src/avlnode.js
@@ -75,6 +75,16 @@ export class Node {
         }
     }
 
+    toJson() {
+        const self = { ...this };
+        delete self.parent;
+        if (this.left)
+            self.left = this.left.toJson();
+        if (this.right)
+            self.right = this.right.toJson();
+        return self;
+    }
+
     rotateLeft(oldRoot) {
         /* These error checks are probably unnecessary since class Node
          * is used exclusively by class Tree

--- a/src/avltree.js
+++ b/src/avltree.js
@@ -37,6 +37,10 @@ export class Tree {
         return out;
     }
 
+    toJson() {
+        return this.root.toJson();
+    }
+
     static fromArray(source) {
         if (!Array.isArray(source))
             throw new AvlTreeConstructionError();


### PR DESCRIPTION
``` console
> @ogrefied/avl-tree@1.0.0 test
> jest

 PASS  __tests__/avltree.test.js
  AVL Tree creation
    ✓ should create an empty tree on construction (3 ms)
    ✓ should return an empty tree when a source array is empty (1 ms)
    ✓ should return proper insertion order when created from an array (2 ms)
    ✓ should throw an error when a source is not an array (1 ms)
  AVL Tree insertions
    ✓ should throw an error when a mismatched type is inserted (1 ms)
    ✓ should throw an error when a nullish value is inserted (1 ms)
    ✓ should throw an error on duplicate key
    ✓ should set the parent of the root node to null (1 ms)
    ✓ should set the parent of a new node
    ✓ should result in a left rotation when added in sequence order (5 ms)
    ✓ should result in a right rotation when added in reverse order (1 ms)
    ✓ should right balance with a double rotation when the new root was left high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root was right high after the insertion (1 ms)
    ✓ should right balance with a double rotation when the new root is balanced after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is right high after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is left high after the insertion (1 ms)
    ✓ should left balance with a double rotation when the new root is balanced after the insertion (1 ms)
    ✓ should right balance with a double rotation on a non-root node (1 ms)
    ✓ should left balance with a double rotation on a non-root node (1 ms)
  AVL Tree output to array
    ✓ should print in infix notation by default (1 ms)
  AVL Tree output to JSON
    ✓ should contain all fields but parent
  AVL Tree search
    ✓ should throw if the search value is null or undefined (1 ms)
    ✓ should return a node that matches the search value exactly
    ✓ should return null if the search term is not found (1 ms)
  AVL Tree depth
    ✓ should be zero for a new tree
    ✓ should be one for a tree with a single node (1 ms)
    ✓ should report the number of left and right traversals if a Metrics object is provided
    ✓ should throw an error if a non-Metrics type is passed as a collector
    ✓ should be two for a balanced tree with three nodes (1 ms)
    ✓ should only result in depth-1 searches when the tree is left high
    ✓ should only result in depth-1 searches when the tree is right high (1 ms)

---------------|---------|----------|---------|---------|-------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
---------------|---------|----------|---------|---------|-------------------
All files      |   97.86 |      100 |    87.5 |   97.83 |                   
 avlerrors.js  |   61.53 |      100 |   61.53 |   61.53 | 14-20,50-62       
 avlmetrics.js |     100 |      100 |     100 |     100 |                   
 avlnode.js    |     100 |      100 |     100 |     100 |                   
 avltree.js    |     100 |      100 |     100 |     100 |                   
---------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       31 passed, 31 total
Snapshots:   0 total
Time:        0.818 s, estimated 1 s
Ran all test suites.
```